### PR TITLE
feat: Supports internal ip in the GKE block

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module "cloud_deploy" {
 | location | Location of the Pipeline | `string` | n/a | yes |
 | pipeline\_name | Name of the Delivery Pipeline | `string` | n/a | yes |
 | project | Project Name | `string` | n/a | yes |
-| stage\_targets | List of object specifications for Deploy Targets | <pre>list(object({<br>    target                            = string<br>    profiles                          = list(string)<br>    gke                               = string<br>    gke_cluster_sa                    = list(string)<br>    artifact_storage                  = string<br>    require_approval                  = bool<br>    execution_configs_service_account = string<br>    worker_pool                       = string<br>  }))</pre> | n/a | yes |
+| stage\_targets | List of object specifications for Deploy Targets | <pre>list(object({<br>    target                            = string<br>    profiles                          = list(string)<br>    gke                               = string<br>    gke_internal_ip_only              = bool<br>    gke_cluster_sa                    = list(string)<br>    artifact_storage                  = string<br>    require_approval                  = bool<br>    execution_configs_service_account = string<br>    worker_pool                       = string<br>  }))</pre> | n/a | yes |
 
 ## Outputs
 
@@ -67,6 +67,7 @@ module "cloud_deploy" {
 |------|-------------|
 | cloud\_trigger\_sa | List of Cloud Build Trigger Service Account |
 | delivery\_pipeline\_and\_target | List of Delivery Pipeline and respective Target |
+| delivery\_pipeline\_id | An identifier for the resource with format `projects/{{project}}/locations/{{location}}/deliveryPipelines/{{name}}` |
 | deployment\_sa | List of Deploy target Execution Service Account |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple_project_private_gke/README.md
+++ b/examples/multiple_project_private_gke/README.md
@@ -26,3 +26,20 @@ Private GKE cluster creation in the target project.
 | <a name="output_cloud_deploy_service_account"></a> [cloud\_deploy\_service\_account](#output\_cloud\_deploy\_service\_account) | List of Deploy target Execution Service Account |
 | <a name="output_cloud_trigger_service_account"></a> [cloud\_trigger\_service\_account](#output\_cloud\_trigger\_service\_account) | List of Cloud Build Trigger Service Account |
 | <a name="output_delivery_pipeline_and_target"></a> [delivery\_pipeline\_and\_target](#output\_delivery\_pipeline\_and\_target) | List of Delivery Pipeline and respective Target |
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| pipeline\_spec | List of object specifications for Delivery Pipeline | <pre>list(object({<br>    pipeline_name = string<br>    location      = string<br>    project       = string<br>    stage_targets = list(object({<br>      target                            = string<br>      profiles                          = list(string)<br>      gke                               = string<br>      gke_cluster_sa                    = list(string)<br>      artifact_storage                  = string<br>      require_approval                  = bool<br>      execution_configs_service_account = string<br>      worker_pool                       = string<br>    }))<br>    cloud_trigger_sa = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cloud\_deploy\_service\_account | List of Deploy target Execution Service Account |
+| cloud\_trigger\_service\_account | List of Cloud Build Trigger Service Account |
+| delivery\_pipeline\_and\_target | List of Delivery Pipeline and respective Target |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/multiple_project_public_gke/README.md
+++ b/examples/multiple_project_public_gke/README.md
@@ -41,3 +41,20 @@ No resources.
 | <a name="output_cloud_deploy_service_account"></a> [cloud\_deploy\_service\_account](#output\_cloud\_deploy\_service\_account) | List of Deploy target Execution Service Account |
 | <a name="output_cloud_trigger_service_account"></a> [cloud\_trigger\_service\_account](#output\_cloud\_trigger\_service\_account) | List of Cloud Build Trigger Service Account |
 | <a name="output_delivery_pipeline_and_target"></a> [delivery\_pipeline\_and\_target](#output\_delivery\_pipeline\_and\_target) | List of Delivery Pipeline and respective Target |
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| pipeline\_spec | List of object specifications for Delivery Pipeline | <pre>list(object({<br>    pipeline_name = string<br>    location      = string<br>    project       = string<br>    stage_targets = list(object({<br>      target                            = string<br>      profiles                          = list(string)<br>      gke                               = string<br>      gke_cluster_sa                    = list(string)<br>      artifact_storage                  = string<br>      require_approval                  = bool<br>      execution_configs_service_account = string<br>      worker_pool                       = string<br>    }))<br>    cloud_trigger_sa = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cloud\_deploy\_service\_account | List of Deploy target Execution Service Account |
+| cloud\_trigger\_service\_account | List of Cloud Build Trigger Service Account |
+| delivery\_pipeline\_and\_target | List of Delivery Pipeline and respective Target |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/single_project_private_gke/README.md
+++ b/examples/single_project_private_gke/README.md
@@ -23,3 +23,20 @@ Private GKE cluster creation in the same project.
 | <a name="output_cloud_deploy_service_account"></a> [cloud\_deploy\_service\_account](#output\_cloud\_deploy\_service\_account) | List of Deploy target Execution Service Account |
 | <a name="output_cloud_trigger_service_account"></a> [cloud\_trigger\_service\_account](#output\_cloud\_trigger\_service\_account) | List of Cloud Build Trigger Service Account |
 | <a name="output_delivery_pipeline_and_target"></a> [delivery\_pipeline\_and\_target](#output\_delivery\_pipeline\_and\_target) | List of Delivery Pipeline and respective Target |
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| pipeline\_spec | List of object specifications for Delivery Pipeline | <pre>list(object({<br>    pipeline_name = string<br>    location      = string<br>    project       = string<br>    stage_targets = list(object({<br>      target                            = string<br>      profiles                          = list(string)<br>      gke                               = string<br>      gke_cluster_sa                    = list(string)<br>      artifact_storage                  = string<br>      require_approval                  = bool<br>      execution_configs_service_account = string<br>      worker_pool                       = string<br>    }))<br>    cloud_trigger_sa = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cloud\_deploy\_service\_account | List of Deploy target Execution Service Account |
+| cloud\_trigger\_service\_account | List of Cloud Build Trigger Service Account |
+| delivery\_pipeline\_and\_target | List of Delivery Pipeline and respective Target |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/single_project_public_gke/README.md
+++ b/examples/single_project_public_gke/README.md
@@ -21,3 +21,20 @@ GKE cluster creation in the same project.
 | <a name="output_cloud_deploy_service_account"></a> [cloud\_deploy\_service\_account](#output\_cloud\_deploy\_service\_account) | List of Deploy target Execution Service Account |
 | <a name="output_cloud_trigger_service_account"></a> [cloud\_trigger\_service\_account](#output\_cloud\_trigger\_service\_account) | List of Cloud Build Trigger Service Account |
 | <a name="output_delivery_pipeline_and_target"></a> [delivery\_pipeline\_and\_target](#output\_delivery\_pipeline\_and\_target) | List of Delivery Pipeline and respective Target |
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| pipeline\_spec | List of object specifications for Delivery Pipeline | <pre>list(object({<br>    pipeline_name = string<br>    location      = string<br>    project       = string<br>    stage_targets = list(object({<br>      target                            = string<br>      profiles                          = list(string)<br>      gke                               = string<br>      gke_cluster_sa                    = list(string)<br>      artifact_storage                  = string<br>      require_approval                  = bool<br>      execution_configs_service_account = string<br>      worker_pool                       = string<br>    }))<br>    cloud_trigger_sa = string<br>  }))</pre> | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cloud\_deploy\_service\_account | List of Deploy target Execution Service Account |
+| cloud\_trigger\_service\_account | List of Cloud Build Trigger Service Account |
+| delivery\_pipeline\_and\_target | List of Delivery Pipeline and respective Target |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -75,6 +75,7 @@ resource "google_clouddeploy_target" "target" {
   name       = each.value.target
   gke {
     cluster = each.value.gke
+    internal_ip = each.value.gke_internal_ip_only = null ? false : each.value.gke_internal_ip_only 
   }
   require_approval = each.value.require_approval
   project          = var.project

--- a/main.tf
+++ b/main.tf
@@ -75,7 +75,7 @@ resource "google_clouddeploy_target" "target" {
   name       = each.value.target
   gke {
     cluster = each.value.gke
-    internal_ip = each.value.gke_internal_ip_only = null ? false : each.value.gke_internal_ip_only 
+    internal_ip = each.value.gke_internal_ip_only == null ? false : each.value.gke_internal_ip_only 
   }
   require_approval = each.value.require_approval
   project          = var.project

--- a/outputs.tf
+++ b/outputs.tf
@@ -29,3 +29,8 @@ output "delivery_pipeline_and_target" {
   value       = { "google_clouddeploy_delivery_pipeline.delivery_pipeline.id" = flatten([for j in var.stage_targets[*].target : google_clouddeploy_target.target[j].id]) }
   description = "List of Delivery Pipeline and respective Target"
 }
+
+output "delivery_pipeline_id" {
+  description = " An identifier for the resource with format `projects/{{project}}/locations/{{location}}/deliveryPipelines/{{name}}`"
+  value = google_clouddeploy_delivery_pipeline.delivery_pipeline.id
+}

--- a/variables.tf
+++ b/variables.tf
@@ -19,6 +19,7 @@ variable "stage_targets" {
     target                            = string
     profiles                          = list(string)
     gke                               = string
+    gke_internal_ip_only              = bool 
     gke_cluster_sa                    = list(string)
     artifact_storage                  = string
     require_approval                  = bool

--- a/variables.tf
+++ b/variables.tf
@@ -19,7 +19,7 @@ variable "stage_targets" {
     target                            = string
     profiles                          = list(string)
     gke                               = string
-    gke_internal_ip_only              = bool 
+    gke_internal_ip_only              = bool
     gke_cluster_sa                    = list(string)
     artifact_storage                  = string
     require_approval                  = bool


### PR DESCRIPTION
From the [Cloud Deploy Target](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/clouddeploy_target#internal_ip) allow for this module to configure the property `internal_ip`